### PR TITLE
Adapt to zookeeper logInfo change

### DIFF
--- a/hdfs_ha.go
+++ b/hdfs_ha.go
@@ -14,8 +14,9 @@ type HdfsHa struct {
 	ZkBreadCrumbPath string
 }
 
-func New(zkServers string, zkTimeout time.Duration, nameservice string) (*HdfsHa, error) {
-	zkConnection, _, err := zk.Connect(strings.Split(zkServers, ","), zkTimeout)
+func New(zkServers string, zkTimeout time.Duration, nameservice string, logInfo bool) (*HdfsHa, error) {
+	logOption := zk.WithLogInfo(logInfo)
+	zkConnection, _, err := zk.Connect(strings.Split(zkServers, ","), zkTimeout, logOption)
 	if err != nil {
 		return nil, err
 	}

--- a/hdfs_ha_test.go
+++ b/hdfs_ha_test.go
@@ -17,7 +17,7 @@ func TestGetActiveNameNode(t *testing.T) {
 	if nameservice == "" {
 		nameservice = "aa"
 	}
-	ha, err := New(zkServers, 5 * time.Second, nameservice)
+	ha, err := New(zkServers, 5 * time.Second, nameservice, true)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
We should offer an opportunity to control whether they want to log the info into stderr through github.com/samuel/go-zookeeper/zk as the issue #170 has been added in zk.
As this link: https://github.com/samuel/go-zookeeper/pull/170